### PR TITLE
Real properties, default value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   ],
   "require": {
     "php": "^7.2",
+    "ext-json": "*",
     "acelot/automapper": "^1.1",
     "acelot/helpers": "^1.0",
     "respect/validation": "^1.1"

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -12,13 +12,13 @@ class ValidationException extends StructException
     protected $errors;
 
     /**
-     * @param array          $errors
+     * @param string|array   $errors
      * @param Throwable|null $previous
      */
-    public function __construct(array $errors, Throwable $previous = null)
+    public function __construct($errors, Throwable $previous = null)
     {
-        parent::__construct('Validation error', 0, $previous);
-        $this->errors = $errors;
+        parent::__construct(is_string($errors) ? $errors : 'Validation error', 0, $previous);
+        $this->errors = is_array($errors) ? $errors : [];
     }
 
     /**

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -38,7 +38,7 @@ class Schema
      *
      * @return bool
      */
-    public function has(string $name): bool
+    public function hasProp(string $name): bool
     {
         return array_key_exists($name, $this->props);
     }
@@ -49,9 +49,9 @@ class Schema
      * @return Prop
      * @throws \OutOfBoundsException
      */
-    public function get(string $name): Prop
+    public function getProp(string $name): Prop
     {
-        if (!$this->has($name)) {
+        if (!$this->hasProp($name)) {
             throw new \OutOfBoundsException(sprintf('Property "%s" not exists in struct', $name));
         }
 
@@ -63,7 +63,17 @@ class Schema
      *
      * @return Schema
      */
-    public function with(Prop ...$props): Schema
+    public function prop(Prop ...$props): Schema
+    {
+        return $this->withProp(...$props);
+    }
+
+    /**
+     * @param Prop ...$props
+     *
+     * @return Schema
+     */
+    public function withProp(Prop ...$props): Schema
     {
         if (empty($props)) {
             throw new \InvalidArgumentException('At least one prop must be defined');
@@ -82,7 +92,7 @@ class Schema
      *
      * @return Schema
      */
-    public function without(string $name): Schema
+    public function withoutProp(string $name): Schema
     {
         $clone = clone $this;
         unset($clone->props[$name]);

--- a/src/Schema/Prop.php
+++ b/src/Schema/Prop.php
@@ -30,6 +30,16 @@ class Prop
     protected $required;
 
     /**
+     * @var bool
+     */
+    protected $hasDefaultValue;
+
+    /**
+     * @var mixed
+     */
+    protected $defaultValue;
+
+    /**
      * @var array
      */
     protected $meta;
@@ -53,6 +63,8 @@ class Prop
         $this->validator = new AlwaysValid();
         $this->mappers = ['default' => From::create($name)];
         $this->required = true;
+        $this->hasDefaultValue = false;
+        $this->defaultValue = null;
         $this->meta = [];
     }
 
@@ -70,6 +82,16 @@ class Prop
     public function getValidator(): Validatable
     {
         return $this->validator;
+    }
+
+    /**
+     * @param Validatable $validator
+     *
+     * @return Prop
+     */
+    public function validator(Validatable $validator): Prop
+    {
+        return $this->withValidator($validator);
     }
 
     /**
@@ -102,6 +124,17 @@ class Prop
     public function getMapper(string $sourceName): DefinitionInterface
     {
         return $this->mappers[$sourceName];
+    }
+
+    /**
+     * @param DefinitionInterface $definition
+     * @param string              $sourceName
+     *
+     * @return Prop
+     */
+    public function mapper(DefinitionInterface $definition, string $sourceName): Prop
+    {
+        return $this->withMapper($definition, $sourceName);
     }
 
     /**
@@ -162,6 +195,56 @@ class Prop
     }
 
     /**
+     * @return bool
+     */
+    public function hasDefaultValue(): bool
+    {
+        return $this->hasDefaultValue;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return Prop
+     */
+    public function defaultValue($value): Prop
+    {
+        return $this->withDefaultValue($value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return Prop
+     */
+    public function withDefaultValue($value): Prop
+    {
+        $clone = clone $this;
+        $clone->hasDefaultValue = true;
+        $clone->defaultValue = $value;
+        return $clone;
+    }
+
+    /**
+     * @return Prop
+     */
+    public function withoutDefaultValue(): Prop
+    {
+        $clone = clone $this;
+        $clone->hasDefaultValue = false;
+        $clone->defaultValue = null;
+        return $clone;
+    }
+
+    /**
      * @param string $key
      *
      * @return bool
@@ -183,6 +266,17 @@ class Prop
             return $default;
         }
         return $this->meta[$key];
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return Prop
+     */
+    public function meta(string $key, $value): Prop
+    {
+        return $this->withMeta($key, $value);
     }
 
     /**

--- a/tests/Unit/SchemaTest.php
+++ b/tests/Unit/SchemaTest.php
@@ -35,9 +35,9 @@ class SchemaTest extends TestCase
             Prop::create('password')
         );
 
-        $this->assertTrue($schema->has('login'));
-        $this->assertTrue($schema->has('password'));
-        $this->assertFalse($schema->has('name'));
+        $this->assertTrue($schema->hasProp('login'));
+        $this->assertTrue($schema->hasProp('password'));
+        $this->assertFalse($schema->hasProp('name'));
     }
 
     public function testGet()
@@ -47,11 +47,11 @@ class SchemaTest extends TestCase
             Prop::create('password')
         );
 
-        $this->assertEquals(Prop::create('login'), $schema->get('login'));
-        $this->assertEquals(Prop::create('password'), $schema->get('password'));
+        $this->assertEquals(Prop::create('login'), $schema->getProp('login'));
+        $this->assertEquals(Prop::create('password'), $schema->getProp('password'));
 
         $this->expectException(\OutOfBoundsException::class);
-        $schema->get('name');
+        $schema->getProp('name');
     }
 
     public function testWith()
@@ -59,21 +59,21 @@ class SchemaTest extends TestCase
         $schema = new Schema(Prop::create('login'));
         $this->assertCount(1, $schema->getProps());
 
-        $schema = $schema->with(Prop::create('password'));
+        $schema = $schema->withProp(Prop::create('password'));
         $this->assertCount(2, $schema->getProps());
-        $this->assertEquals(Prop::create('password'), $schema->get('password'));
+        $this->assertEquals(Prop::create('password'), $schema->getProp('password'));
 
-        $schema = $schema->with(
+        $schema = $schema->withProp(
             Prop::create('name'),
             Prop::create('birthday')
         );
 
         $this->assertCount(4, $schema->getProps());
-        $this->assertEquals(Prop::create('name'), $schema->get('name'));
-        $this->assertEquals(Prop::create('birthday'), $schema->get('birthday'));
+        $this->assertEquals(Prop::create('name'), $schema->getProp('name'));
+        $this->assertEquals(Prop::create('birthday'), $schema->getProp('birthday'));
 
         $this->expectException(\InvalidArgumentException::class);
-        $schema->with();
+        $schema->withProp();
     }
 
     public function testWithout()
@@ -86,11 +86,11 @@ class SchemaTest extends TestCase
         );
         $this->assertCount(4, $schema->getProps());
 
-        $schema = $schema->without('name');
+        $schema = $schema->withoutProp('name');
         $this->assertCount(3, $schema->getProps());
         $this->assertArrayNotHasKey('name', $schema->getProps());
 
-        $schema = $schema->without('undefined');
+        $schema = $schema->withoutProp('undefined');
         $this->assertCount(3, $schema->getProps());
     }
 }

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -67,10 +67,10 @@ class StructTest extends TestCase
 
         $this->assertInstanceOf(Schema::class, $schema);
 
-        $this->assertTrue($schema->has('login'));
-        $this->assertTrue($schema->has('password'));
-        $this->assertTrue($schema->has('birthday'));
-        $this->assertTrue($schema->has('name'));
+        $this->assertTrue($schema->hasProp('login'));
+        $this->assertTrue($schema->hasProp('password'));
+        $this->assertTrue($schema->hasProp('birthday'));
+        $this->assertTrue($schema->hasProp('name'));
     }
 
     public function testMapFrom()

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -6,6 +6,7 @@ use Acelot\Struct\Exception\UndefinedPropertyException;
 use Acelot\Struct\Exception\ValidationException;
 use Acelot\Struct\Schema;
 use Acelot\Struct\Tests\Fixture\CreateUserModel;
+use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 
 class StructTest extends TestCase
@@ -32,25 +33,26 @@ class StructTest extends TestCase
             'birthday' => new \DateTimeImmutable('1988-08-08')
         ], $model->toArray());
 
-        $this->assertTrue(isset($model->login));
+        $this->assertTrue(property_exists($model, 'login'));
         $this->assertTrue($model->has('login'));
         $this->assertEquals('superhacker', $model->login);
         $this->assertEquals('superhacker', $model->get('login'));
 
-        $this->assertTrue(isset($model->password));
+        $this->assertTrue(property_exists($model, 'password'));
         $this->assertTrue($model->has('password'));
         $this->assertEquals('correcthorsebatterystaple', $model->password);
         $this->assertEquals('correcthorsebatterystaple', $model->get('password'));
 
-        $this->assertTrue(isset($model->birthday));
+        $this->assertTrue(property_exists($model, 'birthday'));
         $this->assertTrue($model->has('birthday'));
         $this->assertEquals(new \DateTimeImmutable('1988-08-08'), $model->birthday);
         $this->assertEquals(new \DateTimeImmutable('1988-08-08'), $model->get('birthday'));
 
-        $this->assertFalse(isset($model->name));
+        $this->assertFalse(property_exists($model, 'name'));
         $this->assertFalse($model->has('name'));
         $this->assertEquals('John Doe', $model->get('name', 'John Doe'));
-        $this->expectException(UndefinedPropertyException::class);
+
+        $this->expectException(Notice::class);
         $name = $model->name;
     }
 
@@ -132,6 +134,7 @@ class StructTest extends TestCase
         ]);
 
         $json = json_encode($model);
-        $this->assertEquals('{"login":"superhacker","password":"correcthorsebatterystaple","birthday":"1988-08-08T00:00:00.000+00:00"}', $json);
+        $this->assertEquals('{"login":"superhacker","password":"correcthorsebatterystaple","birthday":"1988-08-08T00:00:00.000+00:00"}',
+            $json);
     }
 }


### PR DESCRIPTION
- `property_exists` now works natively (no `isset` anymore)
- no magic method `__get()`
- new feature `withDefaultValue` for props
- short methods without `with` prefix